### PR TITLE
Try to read ikfast moveit adapter parameters from group namespace

### DIFF
--- a/descartes_moveit/src/ikfast_moveit_state_adapter.cpp
+++ b/descartes_moveit/src/ikfast_moveit_state_adapter.cpp
@@ -151,10 +151,25 @@ void descartes_moveit::IkFastMoveitStateAdapter::setState(const moveit::core::Ro
 bool descartes_moveit::IkFastMoveitStateAdapter::computeIKFastTransforms()
 {
   // look up the IKFast base and tool frame
-  ros::NodeHandle nh;
+  ros::NodeHandle nh(group_name_);
+  std::string ikfast_base_frame_param_key, ikfast_tool_frame_param_key;
   std::string ikfast_base_frame, ikfast_tool_frame;
-  nh.param<std::string>("ikfast_base_frame", ikfast_base_frame, default_base_frame);
-  nh.param<std::string>("ikfast_tool_frame", ikfast_tool_frame, default_tool_frame);
+  if (nh.searchParam("ikfast_base_frame", ikfast_base_frame_param_key))
+  {
+    nh.getParam(ikfast_base_frame_param_key, ikfast_base_frame);
+  }
+  else
+  {
+    ikfast_base_frame = default_base_frame;
+  }
+  if (nh.searchParam("ikfast_tool_frame", ikfast_tool_frame_param_key))
+  {
+    nh.getParam(ikfast_tool_frame_param_key, ikfast_tool_frame);
+  }
+  else
+  {
+    ikfast_tool_frame = default_tool_frame;
+  }
 
   if (!robot_state_->knowsFrameTransform(ikfast_base_frame))
   {

--- a/descartes_moveit/src/ikfast_moveit_state_adapter.cpp
+++ b/descartes_moveit/src/ikfast_moveit_state_adapter.cpp
@@ -161,6 +161,8 @@ bool descartes_moveit::IkFastMoveitStateAdapter::computeIKFastTransforms()
   else
   {
     ikfast_base_frame = default_base_frame;
+    CONSOLE_BRIDGE_logWarn("IkFastMoveitStateAdapter: IkFast base frame parameter not found. Assuming IkFast "
+                           "plugin defined for base frame: %s", ikfast_base_frame.c_str());
   }
   if (nh.searchParam("ikfast_tool_frame", ikfast_tool_frame_param_key))
   {
@@ -169,6 +171,8 @@ bool descartes_moveit::IkFastMoveitStateAdapter::computeIKFastTransforms()
   else
   {
     ikfast_tool_frame = default_tool_frame;
+    CONSOLE_BRIDGE_logWarn("IkFastMoveitStateAdapter: IkFast tool frame parameter not found. Assuming IkFast "
+                           "plugin defined for tool frame: %s", ikfast_tool_frame.c_str());
   }
 
   if (!robot_state_->knowsFrameTransform(ikfast_base_frame))


### PR DESCRIPTION
This adjusts the parameter reading in `IkFastMoveitStateAdapter` to try to read its parameters from a _private-ish_ namespace first.

The rationale behind this is that this class may be instantiated multiple times inside a given node, each time for a different _group_ and using a different IkFast plugin, and therefore needing different settings for the base/tool frame configuration.

The existing code would use either the value configured in a parameter (e.g. `NODE_NAMESPACE/ikfast_base_frame`), or a default otherwise. But it was not possible to set different values for different instances of the class. The new logic will perform a upwards lookup for the parameter starting in a nested namespace with the name of the relevant _group_ (e.g. `NODE_NAMESPACE/GROUP_NAME/ikfast_base_frame`).